### PR TITLE
fix: update Command for 5.0

### DIFF
--- a/.changeset/rare-pianos-listen.md
+++ b/.changeset/rare-pianos-listen.md
@@ -1,0 +1,18 @@
+---
+'@just-web/app': patch
+'@just-web/log': patch
+'@just-web/types': patch
+'@just-web/states': patch
+'@just-web/browser': patch
+'@just-web/browser-keyboard': patch
+'@just-web/browser-preferences': patch
+'@just-web/commands': patch
+'@just-web/keyboard': patch
+'@just-web/os': patch
+'@just-web/preferences': patch
+'@just-web/routes': patch
+'@just-web/presets-browser': patch
+'@just-web/testing': patch
+---
+
+Update `type-plus`

--- a/.changeset/thick-bats-double.md
+++ b/.changeset/thick-bats-double.md
@@ -1,0 +1,15 @@
+---
+'@just-web/commands': major
+---
+
+Remove `JustCommand`.
+
+Remove `Command_WithDefault`. Now use the same `Command` type.
+
+`Command` generic type changed to `F` in order to work with function overloads.
+
+`Command.handler` and `Command.defineArgs` are removed.
+
+`connect()` is now the only way to setup the command.
+
+`handlerRegistry.register` is simplified to just take `id`.

--- a/frameworks/app/package.json
+++ b/frameworks/app/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "iso-error": "~4.4.0",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/frameworks/log/package.json
+++ b/frameworks/log/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@just-func/types": "^0.5.0",
     "standard-log": "^11.1.0",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/frameworks/types/package.json
+++ b/frameworks/types/package.json
@@ -59,7 +59,7 @@
     "rimraf": "~3.0.2",
     "size-limit": "~8.1.0",
     "standard-log": "^11.1.0",
-    "type-plus": "^4.16.0",
+    "type-plus": "^4.18.0",
     "typescript": "^4.8.4"
   },
   "size-limit": [

--- a/libraries/states/package.json
+++ b/libraries/states/package.json
@@ -46,7 +46,7 @@
     "@just-web/log": "workspace:^",
     "immer": "github:unional/immer#master",
     "tersify": "^3.10.2",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/browser-keyboard/package.json
+++ b/plugins/browser-keyboard/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "mousetrap": "~1.6.5",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/browser-preferences/package.json
+++ b/plugins/browser-preferences/package.json
@@ -45,7 +45,7 @@
     "@types/base-64": "^1.0.0",
     "base-64": "^1.0.0",
     "immer": "github:unional/immer#master",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/browser/package.json
+++ b/plugins/browser/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "iso-error": "~4.4.0",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/commands/package.json
+++ b/plugins/commands/package.json
@@ -41,10 +41,9 @@
     "verify:build": "run-s clean build depcheck"
   },
   "dependencies": {
-    "just-func": "^0.2.3",
     "sentence-case": "~3.0.4",
     "tersify": "^3.10.2",
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/commands/ts/command.spec.ts
+++ b/plugins/commands/ts/command.spec.ts
@@ -1,10 +1,9 @@
 import keyboardPlugin, { KeyboardContext, KeyboardOptions } from '@just-web/keyboard'
 import { createMemoryLogReporter, LogOptions, logTestPlugin } from '@just-web/log'
 import { a } from 'assertron'
-import { JustFunction, JustUno } from 'just-func'
 import { configGlobal } from 'standard-log'
-import { isType } from 'type-plus'
-import plugin, { command, CommandsContext, CommandsOptions, justCommand } from '.'
+import { CanAssign, ExtractFunction, isType } from 'type-plus'
+import plugin, { command, CommandsContext, CommandsOptions } from '.'
 
 function setupPlugin(options?: LogOptions & KeyboardOptions & CommandsOptions) {
   const [{ log }] = logTestPlugin(options).init()
@@ -12,226 +11,6 @@ function setupPlugin(options?: LogOptions & KeyboardOptions & CommandsOptions) {
   const [{ commands }] = plugin(options).init({ log, keyboard })
   return [{ log, keyboard, commands }]
 }
-
-describe(`${justCommand.name}()`, () => {
-  it('can be called with string id', () => {
-    justCommand(['some-command'])
-  })
-
-  it('can be called with CommandContribution', () => {
-    // note that all other fields in CommandContribution are optional
-    justCommand([{ id: 'some-command' }])
-    justCommand([{ id: 'some-command', title: 'Do some work' }])
-  })
-
-  it('can be called with KeyBindingContribution', () => {
-    justCommand([{ id: 'some-command', key: 'ctrl+s' }])
-    justCommand([{ id: 'some-command', mac: 'cmd+s' }])
-  })
-
-  it('can provide a default handler (and the type is inferred)', () => {
-    const cmd = justCommand([{ id: 'some-command' }, (v: number) => [v + 1]])
-
-    type P = Parameters<typeof cmd>
-    type R = ReturnType<typeof cmd>
-    isType.equal<true, [v: number], P>()
-    isType.equal<true, JustUno<number>, R>()
-  })
-
-  it('can specify the type of the command', () => {
-    const cmd = justCommand<[], JustUno<number>>(['some-command'])
-
-    type P = Parameters<typeof cmd>
-    type R = ReturnType<typeof cmd>
-    isType.equal<true, [], P>()
-    isType.equal<true, JustUno<number>, R>()
-
-    cmd.defineHandler(() => [1])
-    isType.equal<true, [JustFunction<[], JustUno<number>>], Parameters<typeof cmd.defineHandler>>()
-
-    cmd.defineArgs()
-    type DAP = Parameters<typeof cmd.defineArgs>
-    isType.equal<true, [], DAP>()
-  })
-
-  it('can be added directly to contributions', () => {
-    const [{ commands }] = setupPlugin()
-    const inc = justCommand([{
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1'
-    }])
-    commands.contributions.add(inc)
-
-    const actual = commands.contributions.list().find(c => c.id === 'plugin-a.increment')!
-    a.satisfies(actual, {
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1'
-    })
-  })
-
-  it('can be registered directly to handlers', () => {
-    const [{ commands }] = setupPlugin()
-
-    const inc = justCommand([{
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1'
-    }, (v: number) => [v + 1]])
-
-    commands.handlers.register(inc)
-
-    expect(commands.handlers.invoke(inc.id, 3)).toEqual([4])
-  })
-
-  describe(`defineHandler() and defineArgs()`, () => {
-    it('can be used to help work directly from `handlers`', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand<JustUno<number>, JustUno<number>>(['plugin-a.increment'])
-
-      // note that doing it this way `inc()` will not work:
-      // commands.handlers.register(inc.id, inc.defineHandler(v => [v + 1]))
-      // this will as `inc` gets the `handlers` reference.
-      inc.connect([{ commands, keyboard }, inc.defineHandler(v => [v + 1])])
-
-      const result = commands.handlers.invoke(inc.id, ...inc.defineArgs(3))
-
-      expect(result).toEqual([4])
-    })
-  })
-
-  it('can be registered directly to keybindings', () => {
-    const [{ keyboard }] = setupPlugin()
-
-    const inc = justCommand([{
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1',
-      key: 'ctrl+a'
-    }, (v: number) => [v + 1]])
-
-    keyboard.keyBindingContributions.add(inc)
-
-    const actual = keyboard.keyBindingContributions.list().find(c => c.id === 'plugin-a.increment')!
-    a.satisfies(actual, {
-      id: 'plugin-a.increment',
-      key: 'ctrl+a'
-    })
-  })
-
-  describe('invoking the command', () => {
-    it('before connect() emits an error', () => {
-      const memory = createMemoryLogReporter()
-      configGlobal({ reporters: [memory] })
-      const inc = justCommand(['some-command'])
-
-      inc()
-
-      expect(memory.getLogMessagesWithIdAndLevel()).toEqual([
-        `@just-web/log (ERROR) cannot call 'some-command' before connect().`
-      ])
-    })
-
-    it('returns the result of the command', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'increment' }, (v: number) => [v + 1]])
-      inc.connect([{ commands, keyboard }])
-
-      const [result] = inc(3)
-
-      expect(result).toEqual(4)
-    })
-  })
-
-  describe('connect()', () => {
-    it('does not require handler even if no default handler defined', () => {
-      // this is the case when one package defines the command,
-      // and another package provides the implementation.
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand<[value: number], JustUno<number>>([{ id: 'plugin-a.increment' }])
-
-      inc.connect([{ commands, keyboard }])
-
-      isType.equal<true,
-        [[context: CommandsContext & Partial<KeyboardContext>, handler?: (value: number) => JustUno<number>]],
-        Parameters<typeof inc.connect>>()
-    })
-
-    it('can override with another handler', () => {
-      // this is the case when there is a general way to implement a command,
-      // but it can be overridden in specific platform
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment' }, (v: number) => [v + 1]])
-
-      inc.connect([{ commands, keyboard }, v => [v + 2]])
-
-      expect(inc(3)).toEqual([5])
-    })
-
-    it('can be called without handler if the command already have one', () => {
-      // this is the case when the package defines the command,
-      // and provides the implementation together.
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment' }, (v: number) => [v + 1]])
-
-      inc.connect([{ commands, keyboard }])
-
-      expect(inc(3)).toEqual([4])
-    })
-
-    it('string based command will not add to contributions', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand(['plugin-a.increment', (v: number) => [v + 1]])
-
-      inc.connect([{ commands, keyboard }])
-
-      expect(commands.contributions.has('plugin-a.increment')).toBe(false)
-      expect(keyboard.keyBindingContributions.has('plugin-a.increment')).toBe(false)
-    })
-
-    it('object/info based command will be add to contributions', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment' }, (v: number) => [v + 1]])
-
-      inc.connect([{ commands, keyboard }])
-
-      expect(commands.contributions.has('plugin-a.increment')).toBe(true)
-      expect(keyboard.keyBindingContributions.has('plugin-a.increment')).toBe(false)
-    })
-
-    it('object/info based command with key/mac will be add to keybindings', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment', key: 'ctrl+a' }, (v: number) => [v + 1]])
-
-      inc.connect([{ commands, keyboard }])
-
-      expect(commands.contributions.has('plugin-a.increment')).toBe(true)
-      expect(keyboard.keyBindingContributions.has('plugin-a.increment')).toBe(true)
-    })
-
-    it('will note add to contribution if handler is not defined', () => {
-      // this allows the implementation to connect the command,
-      // instead of getting duplicate registration and get ignored.
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment', key: 'ctrl+a' }])
-
-      inc.connect([{ commands, keyboard }])
-
-      expect(commands.contributions.has('plugin-a.increment')).toBe(false)
-      expect(keyboard.keyBindingContributions.has('plugin-a.increment')).toBe(false)
-    })
-
-    it(`works without KeyboardContext, which will skip the registration`, () => {
-      const [{ commands }] = setupPlugin()
-      const inc = justCommand([{ id: 'plugin-a.increment', key: 'ctrl+i' }, (v: number) => [v + 1]])
-
-      inc.connect([{ commands }])
-
-      expect(inc(3)).toEqual([4])
-    })
-  })
-})
 
 describe(`${command.name}()`, () => {
   it('can be called with string id', () => {
@@ -259,20 +38,23 @@ describe(`${command.name}()`, () => {
   })
 
   it('can specify the type of the command', () => {
-    const cmd = command<[], number>('some-command')
+    const cmd = command<() => number>('some-command')
 
-    type P = Parameters<typeof cmd>
-    type R = ReturnType<typeof cmd>
-    isType.equal<true, [], P>()
-    isType.equal<true, number, R>()
+    isType.equal<true, () => number, ExtractFunction<typeof cmd>>()
 
     cmd.defineHandler(() => 1)
     type PDH = Parameters<typeof cmd.defineHandler>
     isType.equal<true, [() => number], PDH>()
+  })
 
-    cmd.defineArgs()
-    type DAP = Parameters<typeof cmd.defineArgs>
-    isType.equal<true, [], DAP>()
+  it('can specify type with function overloads', () => {
+    const cmd = command<{
+      (): number,
+      (v: string): string
+    }>('overload')
+
+    type C = typeof cmd
+    isType.t<CanAssign<C, { (): number, (v: string): string }>>()
   })
 
   it('can be added directly to contributions', () => {
@@ -292,59 +74,10 @@ describe(`${command.name}()`, () => {
     })
   })
 
-  it('can be registered directly to handlers', () => {
-    const [{ commands }] = setupPlugin()
-
-    const inc = command({
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1',
-    }, (v: number) => [v + 1])
-
-    commands.handlers.register(inc)
-
-    expect(commands.handlers.invoke(inc.id, 3)).toEqual([4])
-  })
-
   it('uses id as the function name', () => {
     const cmd = command('someCommand')
 
     expect(cmd.name).toEqual('someCommand')
-  })
-
-  describe(`defineHandler() and defineArgs()`, () => {
-    it('can be used to help work directly from `handlers`', () => {
-      const [{ commands, keyboard }] = setupPlugin()
-      const inc = command<[id: number], number>('plugin-a.increment')
-
-      // note that doing it this way `inc()` will not work:
-      // commands.handlers.register(inc.id, inc.defineHandler(v => [v + 1]))
-      // this will as `inc` gets the `handlers` reference.
-      inc.connect({ commands, keyboard }, inc.defineHandler(v => v + 1))
-
-      const result = commands.handlers.invoke(inc.id, ...inc.defineArgs(3))
-
-      expect(result).toEqual(4)
-    })
-  })
-
-  it('can be registered directly to keybindings', () => {
-    const [{ keyboard }] = setupPlugin()
-
-    const inc = command({
-      id: 'plugin-a.increment',
-      title: 'Increment',
-      description: 'Increment input value by 1',
-      key: 'ctrl+a'
-    }, (v: number) => [v + 1])
-
-    keyboard.keyBindingContributions.add(inc)
-
-    const actual = keyboard.keyBindingContributions.list().find(c => c.id === 'plugin-a.increment')!
-    a.satisfies(actual, {
-      id: 'plugin-a.increment',
-      key: 'ctrl+a'
-    })
   })
 
   describe('invoking the command', () => {
@@ -376,7 +109,7 @@ describe(`${command.name}()`, () => {
       // this is the case when one package defines the command,
       // and another package provides the implementation.
       const [{ commands, keyboard }] = setupPlugin()
-      const inc = command<[value: number], number>({ id: 'plugin-a.increment' })
+      const inc = command<(value: number) => number>({ id: 'plugin-a.increment' })
 
       inc.connect({ commands, keyboard })
 

--- a/plugins/commands/ts/handlers.ts
+++ b/plugins/commands/ts/handlers.ts
@@ -2,7 +2,7 @@ import { LogContext, logLevels } from '@just-web/log'
 import { createRegistry } from '@just-web/states'
 import { tersify } from 'tersify'
 import type { AnyFunction } from 'type-plus'
-import type { CommandHandler, HandlerRegistry } from './types'
+import type { HandlerRegistry } from './types'
 
 export namespace handlerRegistry {
   export type Options = Record<string, AnyFunction>
@@ -19,17 +19,14 @@ export function handlerRegistry(
     /**
      * register handler for specified command.
      */
-    register(command: string | CommandHandler, handler?: AnyFunction) {
-      const [id, hdr] = typeof command === 'string'
-        ? [command, handler!]
-        : [command.id, command.handler]
+    register(id: string, handler: AnyFunction) {
       logger.trace('register', id)
       const commands = registry.get()
       if (commands[id]) {
         logger.notice(`Registring a new handler for '${id}'. Please make sure this is expected.`)
-        logger.on(logLevels.debug, log => log(`overrideing handler: ${tersify(hdr)}`))
+        logger.on(logLevels.debug, log => log(`overrideing handler: ${tersify(handler)}`))
       }
-      registry.update(m => { m[id] = hdr })
+      registry.update(m => { m[id] = handler })
     },
     invoke(id: string, ...args: any[]) {
       logger.trace('invoke', id)

--- a/plugins/commands/ts/index.spec.ts
+++ b/plugins/commands/ts/index.spec.ts
@@ -2,7 +2,6 @@ import keyboardPlugin from '@just-web/keyboard'
 import { logTestPlugin } from '@just-web/log'
 import { logEqual } from '@just-web/testing'
 import { AssertOrder } from 'assertron'
-import { justValue } from 'just-func'
 import commandsPlugin, { showCommandPalette } from '.'
 
 describe('plugin.init()', () => {
@@ -41,7 +40,7 @@ describe('plugin.init()', () => {
     const [{ commands }] = commandsPlugin().init({ log, keyboard })
     const o = new AssertOrder(1)
 
-    showCommandPalette.connect({ commands, keyboard }, () => (o.once(1), justValue()))
+    showCommandPalette.connect({ commands, keyboard }, () => o.once(1))
 
     commands.showCommandPalette()
     o.end()

--- a/plugins/commands/ts/index.ts
+++ b/plugins/commands/ts/index.ts
@@ -2,14 +2,14 @@ import type { KeyboardContext } from '@just-web/keyboard'
 import type { LogContext } from '@just-web/log'
 import { definePlugin } from '@just-web/types'
 import type { AnyFunction } from 'type-plus'
-import { command, justCommand } from './command'
+import { command } from './command'
 import { contributionRegistry } from './contributions'
 import { handlerRegistry } from './handlers'
 import type { CommandContribution, CommandsContext } from './types'
 
 export * from './command'
 export * from './formatCommand'
-export type { CommandContribution, CommandHandler, CommandsContext, ContributionRegistry, HandlerRegistry, JustCommand as Command, JustCommand_WithDefault as Command_WithDefault } from './types'
+export type { CommandContribution, CommandHandler, CommandsContext, ContributionRegistry, HandlerRegistry, Command } from './types'
 
 export const showCommandPalette = command({
   id: 'just-web.showCommandPalette',
@@ -17,13 +17,6 @@ export const showCommandPalette = command({
   key: 'ctrl+p',
   mac: 'cmd+p'
 })
-
-export const justShowCommandPalette = justCommand([{
-  id: 'just-web.showCommandPalette',
-  commandPalette: false,
-  key: 'ctrl+p',
-  mac: 'cmd+p'
-}])
 
 export type CommandsOptions = {
   commands?: {

--- a/plugins/commands/ts/types.ts
+++ b/plugins/commands/ts/types.ts
@@ -1,6 +1,5 @@
 import { KeyboardContext } from '@just-web/keyboard'
 import type { Registry, WithAdder } from '@just-web/states'
-import { JustEmpty, JustFunction, JustValues } from 'just-func'
 import type { AnyFunction } from 'type-plus'
 
 export type CommandHandler = {
@@ -16,7 +15,6 @@ export type HandlerRegistry = {
    * register handler for the specified command.
    */
   register(id: string, handler: AnyFunction): void,
-  register(info: CommandHandler): void,
   /**
    * invoke a registered command.
    * @param args arguments for the command
@@ -85,51 +83,15 @@ export type CommandsContext = {
   }
 }
 
-export namespace JustCommand {
-  export type Base<
-    Param extends JustValues = JustEmpty,
-    R extends JustValues = JustEmpty
-  > = JustFunction<Param, R> & {
-    id: string,
-    defineHandler(handler: JustFunction<Param, R>): JustFunction<Param, R>
-  } & (Param extends JustEmpty ? {
-    defineArgs<A extends JustEmpty>(): A
-  } : {
-    defineArgs(...args: Param): Param
-  })
-}
-
-export type JustCommand<
-  Params extends JustValues = JustEmpty,
-  R extends JustValues = JustEmpty
-> = JustCommand.Base<Params, R> & {
-  connect(param: [ctx: CommandsContext & Partial<KeyboardContext>, handler?: (...args: Params) => R]): void,
-}
-
-export type JustCommand_WithDefault<
-  Params extends JustValues = JustEmpty,
-  R extends JustValues = JustEmpty
-> = JustCommand.Base<Params, R> & {
-  handler: JustFunction<Params, R>,
-  connect(param: [ctx: CommandsContext & Partial<KeyboardContext>, handler?: (...args: Params) => R]): void,
-}
-
-export namespace Command {
-  export type Base<
-    Params extends any[] = [],
-    R = void
-  > = {
-    (...args: Params): R,
-    id: string,
-    defineHandler(handler: (...args: Params) => R): (...args: Params) => R,
-    defineArgs(...args: Params): Params
-  }
-}
-
 export type Command<
-  Params extends any[] = [],
-  R = void
-> = Command.Base<Params, R> & {
+  F extends AnyFunction = () => void
+> = F & {
+  /**
+   * Id of the command.
+   * It should be unique across the application.
+   * It should follow the `<plugin>.<name>` pattern.
+   */
+  id: string,
   /**
    * Connects a command to the app context.
    *
@@ -146,33 +108,6 @@ export type Command<
    * If you want the command to be available outside (i.e. register to contributions),
    * use the object form `command({...}, ...)`.
    */
-  connect(ctx: CommandsContext & Partial<KeyboardContext>, handler?: (...args: Params) => R): void,
-}
-
-export type Command_WithDefault<
-  Params extends any[] = [],
-  R = void
-> = Command.Base<Params, R> & {
-  handler: (...args: Params) => R,
-  /**
-   * Connects a command to the app context.
-   *
-   * After calling this,
-   * the command function can be called directly which will invoke the command.
-   *
-   * If contribution and/or keybindings are defined in the command,
-   * They will also be registered automatically.
-   *
-   * If the command is defined with string, i.e. `command('name',...)`,
-   * it will not be added to contribution.
-   * It's a shortcut so that local commands can also use `connect()` to setup itself.
-   *
-   * If you want the command to be available outside (i.e. register to contributions),
-   * use the object form `command({...}, ...)`.
-   *
-   * @param handler overrides the default handler.
-   * This is useful if the plugin wants to provide a different implementation.
-   * e.g. implementation for specific platform.
-   */
-  connect(ctx: CommandsContext & Partial<KeyboardContext>, handler?: (...args: Params) => R): void,
+  connect(ctx: CommandsContext & Partial<KeyboardContext>, handler?: F): void,
+  defineHandler(handler: F): F
 }

--- a/plugins/keyboard/package.json
+++ b/plugins/keyboard/package.json
@@ -41,7 +41,7 @@
     "verify:build": "run-s clean build depcheck"
   },
   "dependencies": {
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/plugins/os/package.json
+++ b/plugins/os/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "~3.0.2",
     "size-limit": "~8.1.0",
-    "type-plus": "^4.16.0",
+    "type-plus": "^4.18.0",
     "typescript": "^4.8.4"
   },
   "peerDependencies": {

--- a/plugins/preferences/package.json
+++ b/plugins/preferences/package.json
@@ -67,7 +67,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "~3.0.2",
     "size-limit": "~8.1.0",
-    "type-plus": "^4.16.0",
+    "type-plus": "^4.18.0",
     "typescript": "^4.8.4"
   },
   "peerDependencies": {

--- a/plugins/preferences/ts/preferences.ts
+++ b/plugins/preferences/ts/preferences.ts
@@ -1,8 +1,8 @@
 import { command, CommandsContext } from '@just-web/commands'
 import type { KeyboardContext } from '@just-web/keyboard'
 import { isNothing, SetStateValue, Updater } from '@just-web/states'
-import { definePlugin } from '@just-web/types'
-import { AnyFunction, isType, JSONTypes, MaybePromise } from 'type-plus'
+import { definePlugin, PluginContext } from '@just-web/types'
+import { AnyFunction, extractFunction, isType, JSONTypes, MaybePromise } from 'type-plus'
 
 /**
  * Gets a specific user preference
@@ -12,7 +12,7 @@ import { AnyFunction, isType, JSONTypes, MaybePromise } from 'type-plus'
  * So that will work in MFE.
  * @param defaultValue Optional. The default value to return if the preference doesn't exist.
  */
-export const getUserPreference = command<[key: string, defaultValue?: string], string | undefined>('just-web.getUserPreference')
+export const getUserPreference = command<(key: string, defaultValue?: string) => string | undefined>('just-web.getUserPreference')
 /**
  * Set the specified user preference.
  * @param key The key of the preference to be updated.
@@ -20,7 +20,7 @@ export const getUserPreference = command<[key: string, defaultValue?: string], s
  * If the value or the result of the handler is undefined,
  * the preference should be removed.
  */
-export const setUserPreference = command<[key: string, value: SetStateValue<string | undefined>]>('just-web.setUserPreference')
+export const setUserPreference = command<(key: string, value: SetStateValue<string | undefined>) => void>('just-web.setUserPreference')
 export const clearAllUserPreferences = command({ id: 'just-web.clearAllUserPreferences' })
 
 /**
@@ -37,9 +37,9 @@ const plugin = definePlugin(() => ({
 
     return [{
       preferences: {
-        get: getUserPreference,
-        set: setUserPreference,
-        clearAll: clearAllUserPreferences,
+        get: extractFunction(getUserPreference),
+        set: extractFunction(setUserPreference),
+        clearAll: extractFunction(clearAllUserPreferences),
         createStore
       }
     }]
@@ -48,7 +48,7 @@ const plugin = definePlugin(() => ({
 
 export default plugin
 
-export type PreferencesContext = ReturnType<ReturnType<typeof plugin>['init']>[0]
+export type PreferencesContext = PluginContext<typeof plugin>
 
 function createStore<T extends JSONTypes>(
   this: PreferencesContext['preferences'],

--- a/plugins/routes/package.json
+++ b/plugins/routes/package.json
@@ -41,7 +41,7 @@
     "verify:build": "run-s clean build depcheck"
   },
   "dependencies": {
-    "type-plus": "^4.16.0"
+    "type-plus": "^4.18.0"
   },
   "devDependencies": {
     "@babel/core": "~7.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
       husky: 8.0.1
       jest: 27.5.1
       jest-watch-suspend: 1.1.2_jest@27.5.1
-      jest-watch-toggle-config: 2.0.1_qpxqe4azscpp6ff7thvuzrn5s4
+      jest-watch-toggle-config: 2.0.1_cyjj23dofktqqhirexetoaoaby
       jest-watch-typeahead: 2.2.0_jest@27.5.1
       npm-check-updates: 16.3.11
       npm-run-all: 4.1.5
@@ -83,11 +83,11 @@ importers:
       rimraf: ~3.0.2
       satisfier: ^5.4.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       iso-error: 4.4.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -135,12 +135,12 @@ importers:
       rimraf: ~3.0.2
       size-limit: ~8.1.0
       standard-log: ^11.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-func/types': 0.5.0
       standard-log: 11.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -180,7 +180,7 @@ importers:
       rimraf: ~3.0.2
       size-limit: ~8.1.0
       standard-log: ^11.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     devDependencies:
       '@babel/core': 7.20.2
@@ -200,7 +200,7 @@ importers:
       rimraf: 3.0.2
       size-limit: 8.1.0
       standard-log: 11.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       typescript: 4.8.4
 
   libraries/states:
@@ -224,13 +224,13 @@ importers:
       rimraf: ~3.0.2
       size-limit: ~8.1.0
       tersify: ^3.10.2
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-web/log': link:../../frameworks/log
       immer: github.com/unional/immer/b74706f08e74afffb4ccadf628d12348e811af17
       tersify: 3.10.2
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -274,11 +274,11 @@ importers:
       rimraf: ~3.0.2
       satisfier: ^5.4.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       iso-error: 4.4.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -329,11 +329,11 @@ importers:
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       mousetrap: 1.6.5
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -390,14 +390,14 @@ importers:
       rimraf: ~3.0.2
       satisfier: ^5.4.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-web/states': link:../../libraries/states
       '@types/base-64': 1.0.0
       base-64: 1.0.0
       immer: github.com/unional/immer/b74706f08e74afffb4ccadf628d12348e811af17
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -445,7 +445,6 @@ importers:
       jest-watch-suspend: ^1.1.2
       jest-watch-toggle-config: ^2.0.1
       jest-watch-typeahead: ^2.0.0
-      just-func: ^0.2.3
       npm-check-updates: ~16.4.0
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
@@ -453,13 +452,12 @@ importers:
       size-limit: ~8.1.0
       standard-log: ^11.1.0
       tersify: ^3.10.2
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
-      just-func: 0.2.3
       sentence-case: 3.0.4
       tersify: 3.10.2
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -558,10 +556,10 @@ importers:
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -608,7 +606,7 @@ importers:
       platform: ~1.3.6
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       platform: 1.3.6
@@ -632,7 +630,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       typescript: 4.8.4
 
   plugins/preferences:
@@ -661,7 +659,7 @@ importers:
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-web/states': link:../../libraries/states
@@ -689,7 +687,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       typescript: 4.8.4
 
   plugins/routes:
@@ -715,10 +713,10 @@ importers:
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     devDependencies:
       '@babel/core': 7.20.2
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.20.2
@@ -770,7 +768,7 @@ importers:
       npm-run-all: ^4.1.5
       rimraf: ~3.0.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-web/browser': link:../../plugins/browser
@@ -799,7 +797,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       typescript: 4.8.4
 
   tools/repo-scripts:
@@ -876,7 +874,7 @@ importers:
       rimraf: ~3.0.2
       satisfier: ^5.4.2
       size-limit: ~8.1.0
-      type-plus: ^4.16.0
+      type-plus: ^4.18.0
       typescript: ^4.8.4
     dependencies:
       '@just-web/log': link:../../frameworks/log
@@ -899,7 +897,7 @@ importers:
       npm-run-all: 4.1.5
       rimraf: 3.0.2
       size-limit: 8.1.0
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       typescript: 4.8.4
 
 packages:
@@ -1892,6 +1890,18 @@ packages:
       '@types/yargs': 17.0.13
       chalk: 4.1.2
 
+  /@jest/types/29.3.1:
+    resolution: {integrity: sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.11.9
+      '@types/yargs': 17.0.13
+      chalk: 4.1.2
+    dev: true
+
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -1939,7 +1949,7 @@ packages:
   /@just-func/types/0.4.0:
     resolution: {integrity: sha512-JsBoSndz/rN/cmBgUC9DOFyWdMMJzBwEcaNnayZgzZ30mRnQVKEot5Xqy6X3Cc3+RwAmrowQFudLGTH3kfzXxA==}
     dependencies:
-      type-plus: 4.16.0
+      type-plus: 4.18.0
     dev: false
 
   /@just-func/types/0.5.0:
@@ -2321,6 +2331,10 @@ packages:
 
   /@types/node/18.11.8:
     resolution: {integrity: sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==}
+
+  /@types/node/18.11.9:
+    resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
+    dev: true
 
   /@types/node/18.7.23:
     resolution: {integrity: sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==}
@@ -2895,7 +2909,7 @@ packages:
       path-equal: 1.2.2
       satisfier: 5.4.2
       tersify: 3.10.2
-      type-plus: 4.16.0
+      type-plus: 4.18.0
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -5729,16 +5743,16 @@ packages:
       leven: 3.1.0
       pretty-format: 27.5.1
 
-  /jest-validate/29.2.2:
-    resolution: {integrity: sha512-eJXATaKaSnOuxNfs8CLHgdABFgUrd0TtWS8QckiJ4L/QVDF4KVbZFBBOwCBZHOS0Rc5fOxqngXeGXE3nGQkpQA==}
+  /jest-validate/29.3.1:
+    resolution: {integrity: sha512-N9Lr3oYR2Mpzuelp1F8negJR3YE+L1ebk1rYA5qYo9TTY3f9OWdptLoNSPP9itOCBIRBqjt/S5XHlzYglLN67g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.2.1
+      '@jest/types': 29.3.1
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.2.0
       leven: 3.1.0
-      pretty-format: 29.2.1
+      pretty-format: 29.3.1
     dev: true
 
   /jest-watch-suspend/1.1.2_jest@27.5.1:
@@ -5750,6 +5764,18 @@ packages:
       jest: 27.5.1
       unpartial: 0.6.4
 
+  /jest-watch-toggle-config/2.0.1_cyjj23dofktqqhirexetoaoaby:
+    resolution: {integrity: sha512-qOOPo8vPlDX/hfHCQbJT5NKUvR+Uah+rsCtt+cCmg8oiMNtUvWUO2sqYW/X5PXmWyaoxwI14D8lVEmFy3w6BwQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      jest: '>= 23.4.1'
+      jest-validate: '>= 23.4.0'
+    dependencies:
+      chalk: 4.1.2
+      jest: 27.5.1
+      jest-validate: 29.3.1
+    dev: true
+
   /jest-watch-toggle-config/2.0.1_oppp7y6x7mqpudsh7mhqghjaqy:
     resolution: {integrity: sha512-qOOPo8vPlDX/hfHCQbJT5NKUvR+Uah+rsCtt+cCmg8oiMNtUvWUO2sqYW/X5PXmWyaoxwI14D8lVEmFy3w6BwQ==}
     engines: {node: '>= 10'}
@@ -5760,18 +5786,6 @@ packages:
       chalk: 4.1.2
       jest: 27.5.1
       jest-validate: 27.5.1
-
-  /jest-watch-toggle-config/2.0.1_qpxqe4azscpp6ff7thvuzrn5s4:
-    resolution: {integrity: sha512-qOOPo8vPlDX/hfHCQbJT5NKUvR+Uah+rsCtt+cCmg8oiMNtUvWUO2sqYW/X5PXmWyaoxwI14D8lVEmFy3w6BwQ==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      jest: '>= 23.4.1'
-      jest-validate: '>= 23.4.0'
-    dependencies:
-      chalk: 4.1.2
-      jest: 27.5.1
-      jest-validate: 29.2.2
-    dev: true
 
   /jest-watch-typeahead/2.2.0_jest@27.5.1:
     resolution: {integrity: sha512-cM3Qbw9P+jUYxqUSt53KdDDFRVBG96XA6bsIAG0zffl/gUkNK/kjWcCX7R559BgPWs2/UDrsJHPIw2f6b0qZCw==}
@@ -5959,13 +5973,6 @@ packages:
   /jsonparse/1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
-
-  /just-func/0.2.3:
-    resolution: {integrity: sha512-Rb/dLVchcrT2Fzbn6Ibshn4E3tGRTHomSqStpvpcYJZcnrk8mfe404MkrSMas/lkD6ntqv4yPV1lQFMtwNmguA==}
-    dependencies:
-      '@just-func/types': 0.4.0
-      type-plus: 4.16.0
-    dev: false
 
   /keyv/4.5.0:
     resolution: {integrity: sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==}
@@ -7230,6 +7237,15 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
+  /pretty-format/29.3.1:
+    resolution: {integrity: sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
   /proc-log/2.0.1:
     resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -7880,7 +7896,7 @@ packages:
       '@just-func/types': 0.2.1
       iso-error: 4.4.0
       ms: 2.1.3
-      type-plus: 4.16.0
+      type-plus: 4.18.0
       upper-case: 2.0.2
 
   /stream-transform/2.1.3:
@@ -8340,8 +8356,8 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  /type-plus/4.16.0:
-    resolution: {integrity: sha512-JSfonNaQ7K/8H7F89+xkAcOGIiTUcyO3Unm8qC6/bfVAGgQBiOFBY131Ag56qp9GOAVpo134xm7jJn6GmLhjcg==}
+  /type-plus/4.18.0:
+    resolution: {integrity: sha512-Hds5neDmogRcQheEmdjbEqVq/cE9UUdd9Ic7eCRI2/AzUH1JB+0ha3Hb3Spn2m1PQRBA61kNjbgSLaljNp0L9Q==}
     dependencies:
       tersify: 3.10.2
       unpartial: 1.0.4

--- a/presets/browser/package.json
+++ b/presets/browser/package.json
@@ -68,7 +68,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "~3.0.2",
     "size-limit": "~8.1.0",
-    "type-plus": "^4.16.0",
+    "type-plus": "^4.18.0",
     "typescript": "^4.8.4"
   },
   "peerDependencies": {

--- a/tools/testing/package.json
+++ b/tools/testing/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "~3.0.2",
     "size-limit": "~8.1.0",
-    "type-plus": "^4.16.0",
+    "type-plus": "^4.18.0",
     "typescript": "^4.8.4"
   },
   "size-limit": [


### PR DESCRIPTION
Remove `JustCommand`.

Remove `Command_WithDefault`. Now use the same `Command` type.

`Command` generic type changed to `F` in order to work with function overloads.

`Command.handler` and `Command.defineArgs` are removed.

`connect()` is now the only way to setup the command.

`handlerRegistry.register` is simplified to just take `id`.

Update `type-plus`

fix #128 #168 