### PR TITLE
ci: switch merge automation to the GitHub merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,1 +1,0 @@
-extends: .github

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,26 @@
+name: dependabot-automerge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Majors are left for a human to absorb deliberately: they break builds in
+      # ways CI catches but that need a judgement call.
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 jobs:
   code:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
   release:
     uses: justland/.github/.github/workflows/pnpm-release-changeset.yml@main
     needs: code
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     secrets: inherit
 
   # docgen:


### PR DESCRIPTION
Part of bringing `just-web` onto the current repo standard. This PR is the CI plumbing that the ruleset change depends on; no package content changes, so no changeset.

## What changes

- **`pull-request.yml` gains the `merge_group:` trigger.** A merge-queue candidate branch fires neither `pull_request` nor `push`, so without this the required `code / all-checks` context never starts and the queue waits forever. This has to land *before* the queue rule is added to the ruleset.
- **Mergify is replaced by GitHub auto-merge.** The org Mergify config merges bot PRs with a direct `merge` action, which *bypasses* a merge queue rather than feeding it, and it merges with `rebase`, which discards the per-PR merge commit the repo's merge policy keeps. `dependabot-automerge.yml` arms GitHub's native auto-merge on non-major Dependabot PRs, which enqueues properly. Majors stay manual by design — they break builds in ways CI catches but a human should choose to absorb.
- **The `release` job declares its own `permissions:`.** The repository Actions default is being lowered from `write` to `read`; a release caller with no `permissions:` block under a `read` default fails at workflow resolution with zero jobs and no logs. Declaring the block is least privilege and works under either default.

## Follow-ups landed outside this PR

The `merge_queue` rule and the `code_scanning` rule are added to the `main` ruleset once this is on `main`, and the Actions default is lowered to `read` only after the release `permissions:` block above exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq61zmghpHHWnFLUwTtzXJ