### PR TITLE
ci: publish through the secretless OIDC release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,12 @@ jobs:
     uses: justland/.github/.github/workflows/pnpm-verify.yml@main
 
   release:
-    uses: justland/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: justland/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
     needs: code
     permissions:
       id-token: write
       contents: write
       pull-requests: write
-    secrets: inherit
 
   # docgen:
   #     uses: justland/.github/.github/workflows/pnpm-docs.yml@main

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ catalogs:
       version: 2.1.2
 
 overrides:
-  glob@>=10.2.0 <10.5.0: '>=10.5.0'
+  glob@>=10.2.0 <10.5.0: '>=10.5.0 <11'
 
 patchedDependencies:
   '@changesets/assemble-release-plan': 5bb32d8643179d24c1eac288f85c550808cd537096a78094e05325927ab2424b

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,12 @@ catalog:
   '@repobuddy/vitest': ^2.1.1
 
 overrides:
-  glob@>=10.2.0 <10.5.0: '>=10.5.0'
+  # Upper bound added 2026-09-01. The replacement was previously open-ended
+  # ('>=10.5.0'), so anything this matched would have been rewritten to glob 13
+  # rather than to a patched glob 10. Nothing currently resolves in the matched
+  # range -- rimraf 6 asks for glob ^13 directly -- so the override is dormant.
+  # Exit condition: delete it once no dependency can request glob 10.2-10.4.
+  glob@>=10.2.0 <10.5.0: '>=10.5.0 <11'
 
 patchedDependencies:
   '@changesets/assemble-release-plan': patches/@changesets__assemble-release-plan.patch


### PR DESCRIPTION
Removes the last long-lived credential from the release path, and bounds a dependency override that had an open upper bound.

## The release workflow

Points the release job at `pnpm-release-changeset-oidc.yml`, which `justland/.github` now carries, and drops `secrets: inherit`.

npm trusted publishing is already what authenticates this repo's releases — that is not what changes here. The release run for #505 logged:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```

and all twenty packages it published carry SLSA provenance attestations, verified by reading `registry.npmjs.org` directly.

What the old workflow still pulled in was **`CI_GITHUB_TOKEN`** — a long-lived org PAT, used for checkout and for opening the Version Packages PR. The OIDC workflow uses the built-in `GITHUB_TOKEN` with the elevated `permissions:` this caller already declares, so after this there is no long-lived credential in the release path at all.

The trusted publisher registrations name the **caller** workflow, `release.yml`, which does not change — nothing needs re-registering on npm.

## The `glob` override

The replacement was open-ended:

```yaml
glob@>=10.2.0 <10.5.0: '>=10.5.0'
```

Anything that matched would have been rewritten to **glob 13**, not to a patched glob 10 — a three-major jump wearing a patch's clothes. It is now bounded to `'>=10.5.0 <11'`, with the exit condition in a comment beside it.

To be precise about what this fixes: nothing currently resolves in the matched range (rimraf 6 asks for `glob ^13` directly), so the override is **dormant** and no resolved version changes. `pnpm-lock.yaml` moves by one line, the recorded override string. This is a guard against a future silent jump, not a repair of a live one.

## Changeset

None. Neither change alters any published package.

## Note on proof

This PR's own release run exercises the new workflow end to end except the publish call itself, since it carries no changeset. The publish mechanism is unchanged — OIDC trusted publishing, already proven on #505 with provenance on all twenty packages — so the untested delta is the checkout token and the npm pin. The first changeset-bearing merge after this will exercise the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq61zmghpHHWnFLUwTtzXJ