### PR TITLE
chore(deps): move tersify to 4.0.3

### DIFF
--- a/.changeset/tersify-4.md
+++ b/.changeset/tersify-4.md
@@ -1,0 +1,8 @@
+---
+'@just-web/states': minor
+'@just-web/commands': minor
+---
+
+Move the `tersify` runtime dependency from `^3.12.1` to `^4.0.3`.
+
+Both packages use `tersify` only to render a handler into a debug/trace log message. No API changes, but this is a major bump of a dependency consumers resolve themselves, so it ships as a minor rather than a patch.

--- a/libraries/states/package.json
+++ b/libraries/states/package.json
@@ -62,7 +62,7 @@
 	},
 	"dependencies": {
 		"immer": "^11.1.18",
-		"tersify": "^3.12.1",
+		"tersify": "^4.0.3",
 		"type-plus": "8.0.0-beta.8"
 	},
 	"devDependencies": {

--- a/plugins/commands/package.json
+++ b/plugins/commands/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"sentence-case": "~4.0.0",
-		"tersify": "^3.12.1",
+		"tersify": "^4.0.3",
 		"type-plus": "8.0.0-beta.8"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^11.1.18
         version: 11.1.18
       tersify:
-        specifier: ^3.12.1
-        version: 3.12.1
+        specifier: ^4.0.3
+        version: 4.0.3
       type-plus:
         specifier: 8.0.0-beta.8
         version: 8.0.0-beta.8(typescript@5.9.3)
@@ -603,8 +603,8 @@ importers:
         specifier: ~4.0.0
         version: 4.0.0
       tersify:
-        specifier: ^3.12.1
-        version: 3.12.1
+        specifier: ^4.0.3
+        version: 4.0.3
       type-plus:
         specifier: 8.0.0-beta.8
         version: 8.0.0-beta.8(typescript@5.9.3)


### PR DESCRIPTION
The one item deferred from #503 as needing its own release decision. This is that decision.

## What and why

`@just-web/states` and `@just-web/commands` depend on `tersify` at runtime. #503 took every other bump but held this one back, because a major on a **runtime** dependency changes what consumers resolve, not just what CI builds.

The exposure is small — one call site each, rendering a handler into a debug/trace log message:

- `libraries/states/src/state.ts:89`
- `plugins/commands/src/handlers.ts:25`

## Why `^4.0.3` and not `^4.0.5`

4.0.4 and 4.0.5 are both inside pnpm's `minimumReleaseAge` soak (13h and 15h old at the time of writing, against a 1440-minute gate). Taking either would have written a `minimumReleaseAgeExclude` entry, which bypasses the supply-chain gate this repo deliberately runs. 4.0.3 is 36h old and resolves cleanly with no exclude.

## Size

Both limits still hold, with headroom. The browser example moves:

| output | before | after | limit |
|---|---|---|---|
| `cjs/index.cjs` | 30.15 kB | 32.55 kB | 80 kB |
| `esm/index.mjs` | 16.46 kB | 17.08 kB | 20 kB |

## Changeset

`minor` for both packages, not `patch`. There is no API change, but consumers resolve `tersify` themselves and this moves them across a major — a patch would under-signal that.

## Proof

`pnpm install --frozen-lockfile` clean, `biome check` clean, `knip` clean, and `turbo run build coverage size --force` green across all 62 tasks including the browser suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq61zmghpHHWnFLUwTtzXJ