### PR TITLE
fix(deps): make the supply-chain soak strict and put it where pnpm reads it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 auto-install-peers=true
-minimumreleaseage=1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,14 @@ allowBuilds:
 catalog:
   '@repobuddy/vitest': ^2.1.1
 
+# Supply-chain soak. This lived in .npmrc as `minimumreleaseage=1440`, which npm rejects as an
+# unknown config key and which `pnpm config get minimumReleaseAge` reported as undefined. pnpm
+# did honour it during resolution, but in LOOSE mode: a package inside the window was silently
+# appended to `minimumReleaseAgeExclude` in this file rather than refused. Strict makes pnpm
+# stop and ask instead, so the gate cannot be bypassed by an ordinary `pnpm add`.
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+
 overrides:
   # Upper bound added 2026-09-01. The replacement was previously open-ended
   # ('>=10.5.0'), so anything this matched would have been rewritten to glob 13


### PR DESCRIPTION
## The finding, and a correction to it

`.npmrc` carried `minimumreleaseage=1440`. npm rejects that as an unknown config key — it warns on every npm invocation — and `pnpm config get minimumReleaseAge` reported `undefined`.

That reads like a dead setting, and it was reported to me as one. **It is not.** pnpm honours the value during resolution: this pass caught `knip@6.34.0` and `tersify@4.0.6` as too new, naming the exact 1440-minute cutoff. So the soak was real.

The actual defect is subtler and worse: it ran in **loose** mode. Loose means a package inside the window is *silently appended to `minimumReleaseAgeExclude`* in `pnpm-workspace.yaml` rather than refused. pnpm even says so:

```
Added 1 entry to minimumReleaseAgeExclude in pnpm-workspace.yaml
(set minimumReleaseAgeStrict to true to gate these updates with a prompt)
```

A gate that writes its own exemption is not a gate. Both bypasses happened automatically, from an ordinary `pnpm add`, and would have been committed had I not noticed.

## The change

Moves the setting to `pnpm-workspace.yaml`, where pnpm 11 reads it, and adds `minimumReleaseAgeStrict: true`. `pnpm config get` now reports `1440` and `true` rather than `undefined`. The invalid `.npmrc` key is dropped, which also silences the npm warning.

## Behaviour change to expect

A dependency PR proposing a release younger than 24 hours will now **fail the policy check in CI** instead of quietly carrying an exclusion, and will pass once rebased after the window closes. That is the intent of a soak, but it is friction — lower `minimumReleaseAge` if it is not wanted.

It is already doing its job: `@unional/gizmo@2.3.4`, `iso-error@6.0.5`, `standard-log@13.0.1`, `async-fp@9.0.16` and `tersify@4.0.6` were all published within the last 16 hours and are correctly declined today.

## Proof

`pnpm install --frozen-lockfile` clean against the unchanged lockfile, `biome check` clean, and `pnpm config get` confirms both values.

No published package changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq61zmghpHHWnFLUwTtzXJ