### PR TITLE
fix(deps): stop shipping the type-plus prerelease to consumers

### DIFF
--- a/.changeset/type-plus-stable.md
+++ b/.changeset/type-plus-stable.md
@@ -1,0 +1,20 @@
+---
+'@just-web/app': patch
+'@just-web/browser': patch
+'@just-web/browser-keyboard': patch
+'@just-web/browser-preferences': patch
+'@just-web/commands': patch
+'@just-web/keyboard': patch
+'@just-web/log': patch
+'@just-web/os': patch
+'@just-web/routes': patch
+'@just-web/states': patch
+---
+
+Depend on the stable `type-plus` line (`^7.6.2`) instead of pinning the `8.0.0-beta.8` prerelease.
+
+These ten packages declared `type-plus` as an exact prerelease pin in `dependencies`, so every consumer installing them was pulled onto a prerelease, and a project using two of them could resolve two copies. `type-plus@latest` is 7.6.2 and stays on 7.x deliberately.
+
+The prerelease is also why `require()` of these packages threw `exports is not defined in ES module scope`: `8.0.0-beta.8` declares `"type": "module"` and ships CommonJS under `cjs/` with no `{"type":"commonjs"}` marker. 7.6.2 ships that marker.
+
+Emitted output is unchanged apart from the bundled dependency itself, so this is a patch.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # type-plus keeps `latest` on 7.x deliberately; the 8.x line is prerelease.
+      # A pin that is ALREADY on a prerelease makes each new beta look like an
+      # ordinary patch, which is how `8.0.0-beta.8` reached ten packages here.
+      - dependency-name: "type-plus"
+        versions: [">=8.0.0-0"]

--- a/frameworks/app/package.json
+++ b/frameworks/app/package.json
@@ -75,7 +75,7 @@
 		"@just-web/log": "workspace:^",
 		"@unional/gizmo": "^2.3.1",
 		"iso-error": "~6.0.3",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/repo-scripts": "workspace:^",

--- a/frameworks/id/package.json
+++ b/frameworks/id/package.json
@@ -86,7 +86,7 @@
 		"rimraf": "~6.1.3",
 		"size-limit": "~13.0.3",
 		"tsdown": "^0.22.14",
-		"type-plus": "8.0.0-beta.8",
+		"type-plus": "^7.6.2",
 		"vitest": "^4.1.11"
 	}
 }

--- a/frameworks/log/package.json
+++ b/frameworks/log/package.json
@@ -74,7 +74,7 @@
 		"@just-web/id": "workspace:^",
 		"@unional/gizmo": "^2.3.1",
 		"standard-log": "^12.1.2",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/repo-scripts": "workspace:^",

--- a/libraries/states/package.json
+++ b/libraries/states/package.json
@@ -63,7 +63,7 @@
 	"dependencies": {
 		"immer": "^11.1.18",
 		"tersify": "^4.0.3",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/browser-keyboard/package.json
+++ b/plugins/browser-keyboard/package.json
@@ -73,7 +73,7 @@
 	},
 	"dependencies": {
 		"mousetrap": "~1.6.5",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/browser-preferences/package.json
+++ b/plugins/browser-preferences/package.json
@@ -75,7 +75,7 @@
 		"@just-web/states": "workspace:^",
 		"immer": "^11.1.18",
 		"js-base64": "^3.9.3",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/browser/package.json
+++ b/plugins/browser/package.json
@@ -73,7 +73,7 @@
 	"dependencies": {
 		"@just-web/fetch": "workspace:^",
 		"iso-error": "~6.0.3",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/commands/package.json
+++ b/plugins/commands/package.json
@@ -61,7 +61,7 @@
 	"dependencies": {
 		"sentence-case": "~4.0.0",
 		"tersify": "^4.0.3",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/formatjs/package.json
+++ b/plugins/formatjs/package.json
@@ -85,7 +85,7 @@
 		"rimraf": "~6.1.3",
 		"size-limit": "~13.0.3",
 		"tsdown": "^0.22.14",
-		"type-plus": "8.0.0-beta.8",
+		"type-plus": "^7.6.2",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/plugins/history/package.json
+++ b/plugins/history/package.json
@@ -84,7 +84,7 @@
 		"rimraf": "~6.1.3",
 		"size-limit": "~13.0.3",
 		"tsdown": "^0.22.14",
-		"type-plus": "8.0.0-beta.8",
+		"type-plus": "^7.6.2",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/plugins/keyboard/package.json
+++ b/plugins/keyboard/package.json
@@ -59,7 +59,7 @@
 		"verify": "npm-run-all -p build lint coverage -p size"
 	},
 	"dependencies": {
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/os/package.json
+++ b/plugins/os/package.json
@@ -73,7 +73,7 @@
 	},
 	"dependencies": {
 		"platform": "~1.3.6",
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/plugins/preferences/package.json
+++ b/plugins/preferences/package.json
@@ -89,7 +89,7 @@
 		"rimraf": "~6.1.3",
 		"size-limit": "~13.0.3",
 		"tsdown": "^0.22.14",
-		"type-plus": "8.0.0-beta.8",
+		"type-plus": "^7.6.2",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/plugins/routes/package.json
+++ b/plugins/routes/package.json
@@ -58,7 +58,7 @@
 		"verify": "npm-run-all -p build lint coverage -p size"
 	},
 	"dependencies": {
-		"type-plus": "8.0.0-beta.8"
+		"type-plus": "^7.6.2"
 	},
 	"devDependencies": {
 		"@just-web/app": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/repo-scripts':
         specifier: workspace:^
@@ -231,8 +231,8 @@ importers:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@5.9.3)
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -249,8 +249,8 @@ importers:
         specifier: ^12.1.2
         version: 12.1.2
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/repo-scripts':
         specifier: workspace:^
@@ -295,8 +295,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -347,8 +347,8 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -463,8 +463,8 @@ importers:
         specifier: ~1.6.5
         version: 1.6.5
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -539,8 +539,8 @@ importers:
         specifier: ^3.9.3
         version: 3.9.3
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -603,8 +603,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -786,8 +786,8 @@ importers:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@5.9.3)
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -834,8 +834,8 @@ importers:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@5.9.3)
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -888,8 +888,8 @@ importers:
   plugins/keyboard:
     dependencies:
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -943,8 +943,8 @@ importers:
         specifier: ~1.3.6
         version: 1.3.6
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -1038,8 +1038,8 @@ importers:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@5.9.3)
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -1047,8 +1047,8 @@ importers:
   plugins/routes:
     dependencies:
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@just-web/app':
         specifier: workspace:^
@@ -1154,8 +1154,8 @@ importers:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(typescript@5.9.3)
       type-plus:
-        specifier: 8.0.0-beta.8
-        version: 8.0.0-beta.8(typescript@5.9.3)
+        specifier: ^7.6.2
+        version: 7.6.2
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))

--- a/presets/browser/package.json
+++ b/presets/browser/package.json
@@ -92,7 +92,7 @@
 		"rimraf": "~6.1.3",
 		"size-limit": "~13.0.3",
 		"tsdown": "^0.22.14",
-		"type-plus": "8.0.0-beta.8",
+		"type-plus": "^7.6.2",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
Ten published packages declare `type-plus` as an **exact pin on a prerelease** in `dependencies`. Every consumer installing them is pulled onto `8.0.0-beta.8`, and a project using two of them can resolve two copies. `type-plus@latest` is 7.6.2 and stays on 7.x deliberately — the 8.x line is prerelease, so this is wrong rather than ahead.

That prerelease is also the cause of the repo-wide `require()` failure. `8.0.0-beta.8` declares `"type": "module"`, ships CommonJS under `cjs/`, and has no `cjs/package.json` marking it `{"type":"commonjs"}`, so Node parses its CJS output as ESM and `require()` throws `exports is not defined in ES module scope`. 7.6.2 ships that marker.

Verified from the registry — all ten published manifests carry it:

| package | version | `type-plus` |
|---|---|---|
| `@just-web/app` | 7.3.3 | `8.0.0-beta.8` |
| `@just-web/browser` | 9.1.2 | `8.0.0-beta.8` |
| `@just-web/browser-keyboard` | 9.1.2 | `8.0.0-beta.8` |
| `@just-web/browser-preferences` | 9.1.2 | `8.0.0-beta.8` |
| `@just-web/commands` | 7.4.0 | `8.0.0-beta.8` |
| `@just-web/keyboard` | 7.4.0 | `8.0.0-beta.8` |
| `@just-web/log` | 7.3.3 | `8.0.0-beta.8` |
| `@just-web/os` | 7.3.3 | `8.0.0-beta.8` |
| `@just-web/routes` | 7.2.5 | `8.0.0-beta.8` |
| `@just-web/states` | 7.4.0 | `8.0.0-beta.8` |

Fifteen manifests move in total; the other five have `type-plus` in `devDependencies`, which never reaches a consumer, so only the ten runtime packages take a changeset.

## Verification, not assumption

**Types.** `tsc --noEmit -p tsconfig.build.json` across all eleven affected packages: **0 errors under `8.0.0-beta.8`, 0 under `^7.6.2`**, reports identical. No 7-vs-8 differences here, and no local alias declarations needed.

Worth recording, because the inverse assumption would be costly: this repo's `verify` **does** typecheck. Each package's `build:types` runs `tsc -p tsconfig.build.json --emitDeclarationOnly`, and that config's `include` is `["src", "types"]` — the spec files live under `src/`, so they are checked too.

**Emitted output.** Built both trees with `turbo run build --force` and compared all 430 emitted files by hash. **426 are byte-identical.**

One trap for anyone repeating this: a naive `diff -r` reports many files differing, but nearly every hit is tsdown's `//#region` path comment, which embeds the dependency version —

```
//#region ../../node_modules/.pnpm/type-plus@8.0.0-beta.8_typescript@5.9.3/...
```

Normalise that string before comparing, or an inert change looks non-inert. After normalising: 0 files added, 0 removed, 4 differing. All four are `@just-web/preferences`, and the difference is entirely inside *bundled type-plus code* — arrow functions in the beta versus function expressions in 7.6.2 (`isType.t`, `isType.f`, `isType.equal`). Neither form uses `this` or `arguments`, so they are equivalent. Hence **patch**.

## The regression guard

`ignoreUnstable` only blocks stable → unstable. Once a pin is *already* unstable, every new beta reads as an ordinary patch and flows straight through — which is how one prerelease reached ten packages.

The guard goes in `.github/dependabot.yml`, not a `renovate.json`: Renovate is not installed on this repository, so a Renovate rule would be inert. Dependabot is the active updater here.

```yaml
ignore:
  - dependency-name: "type-plus"
    versions: [">=8.0.0-0"]
```

## Deliberately not included

`@unional/gizmo` 2.3.1 → 2.3.4, which carries the beta transitively into `app`, `id` and `log`. It needs no manifest edit — `^2.3.1` resolves forward on a lockfile refresh — but 2.3.4 was published inside this repo's `minimumReleaseAge` window, which #510 just made strict. Declining it today is the soak working as intended; it clears shortly and an ordinary Dependabot bump takes it.

So this PR fixes the runtime pin for all ten and clears `require()` for the seven with no gizmo path; `app`, `log` and `id` clear when gizmo does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq61zmghpHHWnFLUwTtzXJ